### PR TITLE
V1.0.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# v1.0.3 - ???
+Bugfixes
+1. Array length was not updated when array was shrunk.
+
 # v1.0.2 - Sun Dec 29 22:24:37 SAST 2019
 Additions
 1. Added ds_str_chsubst() functions for substituting characters in a string.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 # v1.0.3 - ???
 Bugfixes
 1. Array length was not updated when array was shrunk.
+2. str_ltrim() bug with not properly null-terminating the result.
 
 # v1.0.2 - Sun Dec 29 22:24:37 SAST 2019
 Additions

--- a/src/ds_array.c
+++ b/src/ds_array.c
@@ -168,7 +168,7 @@ void *ds_array_remove (void ***ll, size_t index)
       return NULL;
 
    size_t len = ds_array_length (*ll);
-   if (index > len)
+   if (index >= len)
       return NULL;
 
    void *ret = (*ll)[index];
@@ -176,5 +176,6 @@ void *ds_array_remove (void ***ll, size_t index)
    memmove (&(*ll)[index], &(*ll)[index + 1],
             (sizeof (void *)) * (len - index));
 
+   (*ll)[-1] = (void *)(uintptr_t)len - 1;
    return ret;
 }

--- a/src/ds_str.c
+++ b/src/ds_str.c
@@ -191,6 +191,8 @@ char *ds_str_ltrim (char *src)
       src[0] = 0;
    }
 
+   slen++;
+
    memmove (&src[0], &src[begin], slen - begin);
    return src;
 }

--- a/src/ds_str.h
+++ b/src/ds_str.h
@@ -21,7 +21,7 @@ extern "C" {
 
    // Append all the strings given in '...' (ending with a NULL) to
    // parameter '(*dst)'. Parameter '(*dst)' is reallocated as necessary
-   // and therefore must be reallocatable (returned by free() or similar).
+   // and therefore must be reallocatable (returned by malloc() or similar).
    // The reallocated '(*dst)' is also returned on success.
    //
    // NULL is returned on error.

--- a/src/ds_str_test.c
+++ b/src/ds_str_test.c
@@ -22,6 +22,12 @@ int main (void)
    char *test_eltrim = NULL;
    char *test_etrim = NULL;
 
+   char *test_etrim1 = NULL;
+   char *test_etrim2 = NULL;
+   char *test_etrim3 = NULL;
+   char *test_etrim4 = NULL;
+   char *test_etrim5 = NULL;
+
    char *test_strsubst = NULL;
 
    /* ******************************************************************* */
@@ -80,6 +86,12 @@ int main (void)
    test_ertrim = ds_str_dup ("   \n   ");
    test_eltrim = ds_str_dup ("   \n   ");
    test_etrim = ds_str_dup ("  \n   ");
+   test_etrim1 = NULL;
+   test_etrim2 = ds_str_dup ("");
+   test_etrim3 = ds_str_dup ("12345");
+   test_etrim4 = ds_str_dup (" 12345");
+   test_etrim5 = ds_str_dup (" 12345");
+   test_etrim5[3] = 0;
 
    if (!test_rtrim || !test_ltrim || !test_trim) {
       fprintf (stderr, "Failed to allocate test strings for trim functions\n");
@@ -93,6 +105,12 @@ int main (void)
    ds_str_rtrim (test_ertrim);
    ds_str_ltrim (test_eltrim);
    ds_str_trim (test_etrim);
+
+   ds_str_ltrim (test_etrim1);
+   ds_str_ltrim (test_etrim2);
+   ds_str_ltrim (test_etrim3);
+   ds_str_ltrim (test_etrim4);
+   ds_str_ltrim (test_etrim5);
 
    /* ******************************************************************* */
 
@@ -127,6 +145,12 @@ int main (void)
    printf ("test_eltrim:   [%s]\n", test_eltrim);
    printf ("test_etrim:    [%s]\n", test_etrim);
 
+   printf ("test_etrim1:    [%s]\n", test_etrim1);
+   printf ("test_etrim2:    [%s]\n", test_etrim2);
+   printf ("test_etrim3:    [%s]\n", test_etrim3);
+   printf ("test_etrim4:    [%s]\n", test_etrim4);
+   printf ("test_etrim5:    [%s]\n", test_etrim5);
+
    printf ("test_strsubst: [%s]\n", test_strsubst);
 
    ret = EXIT_SUCCESS;
@@ -146,6 +170,12 @@ errorexit:
    free (test_ertrim);
    free (test_eltrim);
    free (test_etrim);
+
+   free (test_etrim1);
+   free (test_etrim2);
+   free (test_etrim3);
+   free (test_etrim4);
+   free (test_etrim5);
 
    free (test_strsubst);
 


### PR DESCRIPTION
Two bugfixes:
1. array length was not being updated correctly when removing elements.
2. ds_str_ltrim() was not correctly null-terminating the result.